### PR TITLE
feat: adding support for Scope.REQUEST and TRANSIENT

### DIFF
--- a/src/services/mcp-tools.discovery.ts
+++ b/src/services/mcp-tools.discovery.ts
@@ -1,10 +1,27 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Injectable, OnApplicationBootstrap } from "@nestjs/common";
-import { DiscoveryService, MetadataScanner } from "@nestjs/core";
+import {
+  Injectable,
+  OnApplicationBootstrap,
+  Scope,
+  Type,
+} from "@nestjs/common";
+import {
+  ContextIdFactory,
+  DiscoveryService,
+  MetadataScanner,
+  ModuleRef,
+} from "@nestjs/core";
 import { MCP_TOOL_METADATA_KEY, ToolMetadata } from "../decorators";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError, Progress } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+  Progress,
+} from "@modelcontextprotocol/sdk/types.js";
+import { InstanceWrapper } from "@nestjs/core/injector/instance-wrapper";
 
 export type Context = {
   reportProgress: (progress: Progress) => Promise<void>;
@@ -48,6 +65,12 @@ type ContentResult = {
   isError?: boolean;
 };
 
+type DiscoveredTool = {
+  metadata: ToolMetadata;
+  provider: InstanceWrapper<any>;
+  methodName: string;
+};
+
 const ContentResultZodSchema = z
   .object({
     content: ContentZodSchema.array(),
@@ -58,21 +81,18 @@ const ContentResultZodSchema = z
 class UserError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'UserError';
+    this.name = "UserError";
   }
 }
 
 @Injectable()
 export class McpToolsDiscovery implements OnApplicationBootstrap {
-  private tools: Array<{
-    metadata: ToolMetadata;
-    instance: any;
-    methodName: string;
-  }> = [];
+  private tools: Array<DiscoveredTool> = [];
 
   constructor(
     private readonly discovery: DiscoveryService,
     private readonly metadataScanner: MetadataScanner,
+    private readonly moduleRef: ModuleRef
   ) {}
 
   onApplicationBootstrap() {
@@ -82,30 +102,34 @@ export class McpToolsDiscovery implements OnApplicationBootstrap {
   collectTools() {
     const providers = this.discovery.getProviders();
     const controllers = this.discovery.getControllers();
-    const allInstances = [...providers, ...controllers]
-      .filter((wrapper) => wrapper.instance)
-      .map((wrapper) => wrapper.instance);
+    const allProviders = [...providers, ...controllers];
 
-    allInstances.forEach((instance) => {
-      if (!instance || typeof instance !== 'object') {
+    allProviders.forEach((wrapper) => {
+      if (!wrapper.instance) {
         return;
       }
-      this.metadataScanner.getAllMethodNames(instance).forEach((methodName) => {
-        const methodRef = instance[methodName];
-        const methodMetaKeys = Reflect.getOwnMetadataKeys(methodRef);
 
-        if (!methodMetaKeys.includes(MCP_TOOL_METADATA_KEY)) {
-          return;
-        }
+      this.metadataScanner
+        .getAllMethodNames(wrapper.instance)
+        .forEach((methodName) => {
+          const methodRef = wrapper.instance[methodName];
+          const methodMetaKeys = Reflect.getOwnMetadataKeys(methodRef);
 
-        const metadata: ToolMetadata = Reflect.getMetadata(MCP_TOOL_METADATA_KEY, methodRef);
+          if (!methodMetaKeys.includes(MCP_TOOL_METADATA_KEY)) {
+            return;
+          }
 
-        this.tools.push({
-          metadata,
-          instance,
-          methodName,
+          const metadata: ToolMetadata = Reflect.getMetadata(
+            MCP_TOOL_METADATA_KEY,
+            methodRef
+          );
+
+          this.tools.push({
+            metadata,
+            provider: wrapper,
+            methodName,
+          });
         });
-      });
     });
   }
 
@@ -113,80 +137,115 @@ export class McpToolsDiscovery implements OnApplicationBootstrap {
     // Register list tools handler
     mcpServer.server.setRequestHandler(ListToolsRequestSchema, async () => {
       let tools = this.tools.map((tool) => ({
-          name: tool.metadata.name,
-          description: tool.metadata.description,
-          inputSchema: tool.metadata.parameters
-            ? zodToJsonSchema(tool.metadata.parameters)
-            : undefined,
-        }))
+        name: tool.metadata.name,
+        description: tool.metadata.description,
+        inputSchema: tool.metadata.parameters
+          ? zodToJsonSchema(tool.metadata.parameters)
+          : undefined,
+      }));
       return {
-        tools
+        tools,
       };
     });
 
     // Register call tool handler
-    mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const tool = this.tools.find((tool) => tool.metadata.name === request.params.name);
-
-      if (!tool) {
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}`
+    mcpServer.server.setRequestHandler(
+      CallToolRequestSchema,
+      async (request) => {
+        const tool = this.tools.find(
+          (tool) => tool.metadata.name === request.params.name
         );
-      }
 
-      const schema = tool.metadata.parameters;
-      let parsedParams = request.params.arguments;
-
-      if (schema && schema instanceof z.ZodType) {
-        const result = schema.safeParse(request.params.arguments);
-        if (!result.success) {
+        if (!tool) {
           throw new McpError(
-            ErrorCode.InvalidParams,
-            `Invalid ${request.params.name} parameters: ${JSON.stringify(result.error.format())}`
+            ErrorCode.MethodNotFound,
+            `Unknown tool: ${request.params.name}`
           );
         }
-        parsedParams = result.data;
-      }
 
-      const progressToken = request.params?._meta?.progressToken;
+        const schema = tool.metadata.parameters;
+        let parsedParams = request.params.arguments;
 
-      try {
-        const context = this.createContext(mcpServer, progressToken!);
-        const result = await tool.instance[tool.methodName].call(
-          tool.instance,
-          parsedParams,
-          context
-        );
-
-        // Handle different result types
-        if (typeof result === "string") {
-          return ContentResultZodSchema.parse({
-            content: [{ type: "text", text: result }],
-          });
-        } else if (result && typeof result === "object" && "type" in result) {
-          return ContentResultZodSchema.parse({
-            content: [result],
-          });
-        } else {
-          return ContentResultZodSchema.parse(result);
+        if (schema && schema instanceof z.ZodType) {
+          const result = schema.safeParse(request.params.arguments);
+          if (!result.success) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              `Invalid ${request.params.name} parameters: ${JSON.stringify(
+                result.error.format()
+              )}`
+            );
+          }
+          parsedParams = result.data;
         }
-      } catch (error) {
-        if (error instanceof UserError) {
+
+        const progressToken = request.params?._meta?.progressToken;
+
+        try {
+          const context = this.createContext(mcpServer, progressToken!);
+          const instance = await this.resolveInstance(tool, request);
+
+          const result = await instance[tool.methodName].call(
+            instance,
+            parsedParams,
+            context
+          );
+
+          // Handle different result types
+          if (typeof result === "string") {
+            return ContentResultZodSchema.parse({
+              content: [{ type: "text", text: result }],
+            });
+          } else if (result && typeof result === "object" && "type" in result) {
+            return ContentResultZodSchema.parse({
+              content: [result],
+            });
+          } else {
+            return ContentResultZodSchema.parse(result);
+          }
+        } catch (error) {
+          if (error instanceof UserError) {
+            return {
+              content: [{ type: "text", text: error.message }],
+              isError: true,
+            };
+          }
           return {
-            content: [{ type: "text", text: error.message }],
+            content: [{ type: "text", text: `Error: ${error}` }],
             isError: true,
           };
         }
-        return {
-          content: [{ type: "text", text: `Error: ${error}` }],
-          isError: true,
-        };
       }
-    });
+    );
   }
 
-  private createContext(mcpServer: McpServer, progressToken?: string | number) : Context {
+  private async resolveInstance(tool: DiscoveredTool, request: any) {
+    const contextId = ContextIdFactory.create();
+
+    // Check if provider is singleton/default scope and not request scoped
+    const isSingletonScope =
+      (tool.provider.scope === undefined ||
+        tool.provider.scope === Scope.DEFAULT) &&
+      !tool.provider.isInRequestScope(contextId);
+
+    if (isSingletonScope) {
+      // For singleton scope, return the static instance
+      return tool.provider.instance;
+    }
+
+    // For request scoped providers, resolve dynamically
+    this.moduleRef.registerRequestByContextId(request, contextId);
+    return await this.moduleRef.resolve(
+      tool.provider.metatype as Type<any>,
+      contextId,
+      { strict: false }
+    );
+  }
+
+  private createContext(
+    mcpServer: McpServer,
+    progressToken?: string | number
+  ): Context {
     return {
       reportProgress: async (progress: Progress) => {
         if (progressToken) {


### PR DESCRIPTION
Adding support for `REQUEST` and `TRANSIENT` scope, since it blocks the usage during tenants requests.